### PR TITLE
Generate preload html on build.

### DIFF
--- a/build/css/variables.css
+++ b/build/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 16 Jul 2024 15:26:40 GMT
+ * Generated on Thu, 01 Aug 2024 12:31:10 GMT
  */
 
 :root {
@@ -23,27 +23,27 @@
   --line-height-s: 1.4rem;
   --line-height-xs: 1.2rem;
   --font-medium-italic-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-medium-italic-src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff) format('woff2');
+  --font-medium-italic-src: https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff;
   --font-medium-italic-display: swap;
   --font-medium-italic-style: italic;
   --font-medium-italic-family: Montserrat-MediumItalic;
   --font-medium-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-medium-src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff) format('woff2');
+  --font-medium-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff;
   --font-medium-style: normal;
   --font-medium-display: swap;
   --font-medium-family: Montserrat-Medium;
   --font-semi-bold-italic-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-semi-bold-italic-src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff) format('woff2');
+  --font-semi-bold-italic-src: https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff;
   --font-semi-bold-italic-style: italic;
   --font-semi-bold-italic-display: swap;
   --font-semi-bold-italic-family: Montserrat-SemiBoldItalic;
   --font-semi-bold-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-semi-bold-src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff) format('woff2');
+  --font-semi-bold-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff;
   --font-semi-bold-style: normal;
   --font-semi-bold-display: swap;
   --font-semi-bold-family: Montserrat-SemiBold;
   --font-bold-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-bold-src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff) format('woff2');
+  --font-bold-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff;
   --font-bold-style: normal;
   --font-bold-display: swap;
   --font-bold-family: Montserrat-Bold;

--- a/build/ts/font-preloads.ts
+++ b/build/ts/font-preloads.ts
@@ -1,0 +1,6 @@
+export const fontPreloads =
+`<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff" as="font" type="font/woff2" crossorigin/>
+<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff" as="font" type="font/woff2" crossorigin/>
+<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff" as="font" type="font/woff2" crossorigin/>
+<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff" as="font" type="font/woff2" crossorigin/>
+<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff" as="font" type="font/woff2" crossorigin/>`

--- a/build/ts/index.ts
+++ b/build/ts/index.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 16 Jul 2024 15:26:40 GMT
+ * Generated on Thu, 01 Aug 2024 12:31:10 GMT
  */
 
 export const theme = {
@@ -13,7 +13,7 @@ export const theme = {
       "weight": "700",
       "display": "swap",
       "style": "normal",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     },
     "semiBold": {
@@ -21,7 +21,7 @@ export const theme = {
       "weight": "600",
       "display": "swap",
       "style": "normal",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     },
     "semiBoldItalic": {
@@ -29,7 +29,7 @@ export const theme = {
       "weight": "600",
       "display": "swap",
       "style": "italic",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     },
     "medium": {
@@ -37,7 +37,7 @@ export const theme = {
       "weight": "500",
       "display": "swap",
       "style": "normal",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     },
     "mediumItalic": {
@@ -45,7 +45,7 @@ export const theme = {
       "weight": "500",
       "style": "italic",
       "display": "swap",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     }
   },

--- a/build/ts/index.web.ts
+++ b/build/ts/index.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 16 Jul 2024 15:26:40 GMT
+ * Generated on Thu, 01 Aug 2024 12:31:10 GMT
  */
 
 export const theme = {
@@ -13,7 +13,7 @@ export const theme = {
       "weight": "700",
       "display": "swap",
       "style": "normal",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     },
     "semiBold": {
@@ -21,7 +21,7 @@ export const theme = {
       "weight": "600",
       "display": "swap",
       "style": "normal",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     },
     "semiBoldItalic": {
@@ -29,7 +29,7 @@ export const theme = {
       "weight": "600",
       "display": "swap",
       "style": "italic",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     },
     "medium": {
@@ -37,7 +37,7 @@ export const theme = {
       "weight": "500",
       "display": "swap",
       "style": "normal",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     },
     "mediumItalic": {
@@ -45,7 +45,7 @@ export const theme = {
       "weight": "500",
       "style": "italic",
       "display": "swap",
-      "src": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff) format('woff2')",
+      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff",
       "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "0.0.2",
+  "version": "0.0.10",
   "main": "design-tokens.json",
   "repository": "git@github.com:pass-culture/design-system.git",
   "private": true,

--- a/src/configs/config-fonts.json
+++ b/src/configs/config-fonts.json
@@ -1,0 +1,25 @@
+{
+  "source": ["src/tokens/design-tokens.json"],
+  "platforms": {
+    "css": {
+      "transforms": ["name/cti/kebab"],
+      "buildPath": "build/css/",
+      "files": [
+        {
+          "destination": "font-faces.css",
+          "format": "css/font-faces"
+        }
+      ]
+    },
+    "js": {
+      "transforms": ["name/cti/kebab"],
+      "buildPath": "build/ts/",
+      "files": [
+        {
+          "destination": "font-preloads.ts",
+          "format": "ts/font-preloads"
+        }
+      ]
+    }
+  }
+}

--- a/src/configs/config-pro.json
+++ b/src/configs/config-pro.json
@@ -18,13 +18,6 @@
           "options": {
             "outputReferences": true
           }
-        },
-        {
-          "destination": "font-faces.css",
-          "format": "css/font-faces",
-          "options": {
-            "outputReferences": true
-          }
         }
       ]
     }

--- a/src/tokens/design-tokens.json
+++ b/src/tokens/design-tokens.json
@@ -12,14 +12,14 @@
       "weight": {
         "value": "{fontWeight.bold}"
       },
-      "display":{
-        "value":"swap"
+      "display": {
+        "value": "swap"
       },
       "style": {
         "value": "normal"
       },
       "src": {
-        "value": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff) format('woff2')"
+        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff"
       },
       "unicode-range": {
         "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
@@ -32,14 +32,14 @@
       "weight": {
         "value": "{fontWeight.semiBold}"
       },
-      "display":{
-        "value":"swap"
+      "display": {
+        "value": "swap"
       },
       "style": {
         "value": "normal"
       },
       "src": {
-        "value": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff) format('woff2')"
+        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff"
       },
       "unicode-range": {
         "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
@@ -52,14 +52,14 @@
       "weight": {
         "value": "{fontWeight.semiBold}"
       },
-      "display":{
-        "value":"swap"
+      "display": {
+        "value": "swap"
       },
       "style": {
         "value": "italic"
       },
       "src": {
-        "value": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff) format('woff2')"
+        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff"
       },
       "unicode-range": {
         "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
@@ -72,14 +72,14 @@
       "weight": {
         "value": "{fontWeight.medium}"
       },
-      "display":{
-        "value":"swap"
+      "display": {
+        "value": "swap"
       },
       "style": {
         "value": "normal"
       },
       "src": {
-        "value": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff) format('woff2')"
+        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff"
       },
       "unicode-range": {
         "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
@@ -95,11 +95,11 @@
       "style": {
         "value": "italic"
       },
-      "display":{
-        "value":"swap"
+      "display": {
+        "value": "swap"
       },
       "src": {
-        "value": "url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff) format('woff2')"
+        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff"
       },
       "unicode-range": {
         "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"


### PR DESCRIPTION
Génération de preloads HTML depuis le DS pour pré-charger les polices dans le front de PRO et à l'avenir dans le front de l'app jeune web.

Quelques problèmes :
- Ces `link` doivent ensuite être injectés dans le `index.html` au moment du build de l'app (pro pour l'instant), et j'ai pas trouvé comment importer directement du HTML dans un fichier de ts sur pro. Mais peut-être que vous avez une solution qui évite de passer par un fichier `ts`!
- Là toutes les typos seraient pré-chargées alors que c'est pas forcément ce qu'on souhaite (pas la peine de pré-charger des typos qui sont rarement utilisées). Mais est-ce que le fat de charger une typo ou non fait partie des tokens ? Sinon comment définir quel sous-ensemble de typos preload ?