### PR TITLE
Pc 32993 update font size primitives

### DIFF
--- a/build/css/variables.css
+++ b/build/css/variables.css
@@ -1,15 +1,15 @@
 /**
  * Do not edit directly
- * Generated on Wed, 16 Oct 2024 14:03:27 GMT
+ * Generated on Wed, 13 Nov 2024 14:03:45 GMT
  */
 
 :root {
-  --font-size-xl: 1.75rem;
-  --font-size-l: 1.3125rem;
-  --font-size-m: 1.1875rem;
-  --font-size-s: 1rem;
-  --font-size-xs: 0.875rem;
-  --font-size-xxs: 0.75rem;
+  --font-size-xxl: 1.75rem;
+  --font-size-xl: 1.3125rem;
+  --font-size-l: 1.1875rem;
+  --font-size-m: 1rem;
+  --font-size-s: 0.875rem;
+  --font-size-xs: 0.75rem;
   --font-weight-semi-bold: 600;
   --font-weight-medium: 500;
   --font-weight-bold: 700;
@@ -48,55 +48,55 @@
   --color-black: #161617;
   --typography-button-color: var(--color-black);
   --typography-button-line-height: var(--line-height-m);
-  --typography-button-font-size: var(--font-size-s);
+  --typography-button-font-size: var(--font-size-m);
   --typography-button-font-family: var(--font-bold-family);
   --typography-body-italic-accent-color: var(--color-black);
   --typography-body-italic-accent-line-height: var(--line-height-m);
-  --typography-body-italic-accent-font-size: var(--font-size-s);
+  --typography-body-italic-accent-font-size: var(--font-size-m);
   --typography-body-italic-accent-font-family: var(--font-semi-bold-italic-family);
   --typography-body-italic-color: var(--color-black);
   --typography-body-italic-line-height: var(--line-height-m);
-  --typography-body-italic-font-size: var(--font-size-s);
+  --typography-body-italic-font-size: var(--font-size-m);
   --typography-body-italic-font-family: var(--font-medium-italic-family);
   --typography-body-accent-xs-color: var(--color-black);
   --typography-body-accent-xs-line-height: var(--line-height-xs);
-  --typography-body-accent-xs-font-size: var(--font-size-xxs);
+  --typography-body-accent-xs-font-size: var(--font-size-xs);
   --typography-body-accent-xs-font-family: var(--font-semi-bold-family);
   --typography-body-accent-s-color: var(--color-black);
   --typography-body-accent-s-line-height: var(--line-height-s);
-  --typography-body-accent-s-font-size: var(--font-size-xs);
+  --typography-body-accent-s-font-size: var(--font-size-s);
   --typography-body-accent-s-font-family: var(--font-semi-bold-family);
   --typography-body-accent-color: var(--color-black);
   --typography-body-accent-line-height: var(--line-height-m);
-  --typography-body-accent-font-size: var(--font-size-s);
+  --typography-body-accent-font-size: var(--font-size-m);
   --typography-body-accent-font-family: var(--font-semi-bold-family);
   --typography-body-xs-color: var(--color-black);
   --typography-body-xs-line-height: var(--line-height-xs);
-  --typography-body-xs-font-size: var(--font-size-xxs);
+  --typography-body-xs-font-size: var(--font-size-xs);
   --typography-body-xs-font-family: var(--font-medium-family);
   --typography-body-s-color: var(--color-black);
   --typography-body-s-line-height: var(--line-height-s);
-  --typography-body-s-font-size: var(--font-size-xs);
+  --typography-body-s-font-size: var(--font-size-s);
   --typography-body-s-font-family: var(--font-medium-family);
   --typography-body-color: var(--color-black);
   --typography-body-line-height: var(--line-height-m);
-  --typography-body-font-size: var(--font-size-s);
+  --typography-body-font-size: var(--font-size-m);
   --typography-body-font-family: var(--font-medium-family);
   --typography-title4-color: var(--color-black);
   --typography-title4-line-height: var(--line-height-l);
-  --typography-title4-font-size: var(--font-size-s);
+  --typography-title4-font-size: var(--font-size-m);
   --typography-title4-font-family: var(--font-bold-family);
   --typography-title3-color: var(--color-black);
   --typography-title3-line-height: var(--line-height-xl);
-  --typography-title3-font-size: var(--font-size-m);
+  --typography-title3-font-size: var(--font-size-l);
   --typography-title3-font-family: var(--font-bold-family);
   --typography-title2-color: var(--color-black);
   --typography-title2-line-height: var(--line-height-xxl);
-  --typography-title2-font-size: var(--font-size-l);
+  --typography-title2-font-size: var(--font-size-xl);
   --typography-title2-font-family: var(--font-bold-family);
   --typography-title1-color: var(--color-black);
   --typography-title1-line-height: var(--line-height-xxxl);
-  --typography-title1-font-size: var(--font-size-xl);
+  --typography-title1-font-size: var(--font-size-xxl);
   --typography-title1-font-family: var(--font-bold-family);
   --font-medium-italic-weight: var(--font-weight-medium);
   --font-medium-weight: var(--font-weight-medium);

--- a/build/css/variables.css
+++ b/build/css/variables.css
@@ -1,12 +1,13 @@
 /**
  * Do not edit directly
- * Generated on Wed, 13 Nov 2024 14:03:45 GMT
+ * Generated on Wed, 27 Nov 2024 12:32:08 GMT
  */
 
 :root {
-  --font-size-xxl: 1.75rem;
-  --font-size-xl: 1.3125rem;
-  --font-size-l: 1.1875rem;
+  --font-size-xxxl: 1.75rem;
+  --font-size-xxl: 1.3125rem;
+  --font-size-xl: 1.1875rem;
+  --font-size-l: 1.0625rem;
   --font-size-m: 1rem;
   --font-size-s: 0.875rem;
   --font-size-xs: 0.75rem;
@@ -84,19 +85,19 @@
   --typography-body-font-family: var(--font-medium-family);
   --typography-title4-color: var(--color-black);
   --typography-title4-line-height: var(--line-height-l);
-  --typography-title4-font-size: var(--font-size-m);
+  --typography-title4-font-size: var(--font-size-l);
   --typography-title4-font-family: var(--font-bold-family);
   --typography-title3-color: var(--color-black);
   --typography-title3-line-height: var(--line-height-xl);
-  --typography-title3-font-size: var(--font-size-l);
+  --typography-title3-font-size: var(--font-size-xl);
   --typography-title3-font-family: var(--font-bold-family);
   --typography-title2-color: var(--color-black);
   --typography-title2-line-height: var(--line-height-xxl);
-  --typography-title2-font-size: var(--font-size-xl);
+  --typography-title2-font-size: var(--font-size-xxl);
   --typography-title2-font-family: var(--font-bold-family);
   --typography-title1-color: var(--color-black);
   --typography-title1-line-height: var(--line-height-xxxl);
-  --typography-title1-font-size: var(--font-size-xxl);
+  --typography-title1-font-size: var(--font-size-xxxl);
   --typography-title1-font-family: var(--font-bold-family);
   --font-medium-italic-weight: var(--font-weight-medium);
   --font-medium-weight: var(--font-weight-medium);

--- a/build/ts/index.ts
+++ b/build/ts/index.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 13 Nov 2024 14:03:45 GMT
+ * Generated on Wed, 27 Nov 2024 12:32:08 GMT
  */
 
 export const theme = {
@@ -67,9 +67,10 @@ export const theme = {
     "xs": "12px",
     "s": "14px",
     "m": "16px",
-    "l": "19px",
-    "xl": "21px",
-    "xxl": "28px"
+    "l": "17px",
+    "xl": "19px",
+    "xxl": "21px",
+    "xxxl": "28px"
   },
   "typography": {
     "title1": {
@@ -92,7 +93,7 @@ export const theme = {
     },
     "title4": {
       "fontFamily": "Montserrat-Bold",
-      "fontSize": "16px",
+      "fontSize": "17px",
       "lineHeight": "27.2px",
       "color": "#161617"
     },

--- a/build/ts/index.ts
+++ b/build/ts/index.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 16 Oct 2024 14:03:27 GMT
+ * Generated on Wed, 13 Nov 2024 14:03:45 GMT
  */
 
 export const theme = {
@@ -64,12 +64,12 @@ export const theme = {
     "semiBold": "600"
   },
   "fontSize": {
-    "xxs": "12px",
-    "xs": "14px",
-    "s": "16px",
-    "m": "19px",
-    "l": "21px",
-    "xl": "28px"
+    "xs": "12px",
+    "s": "14px",
+    "m": "16px",
+    "l": "19px",
+    "xl": "21px",
+    "xxl": "28px"
   },
   "typography": {
     "title1": {

--- a/build/ts/index.web.ts
+++ b/build/ts/index.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 16 Oct 2024 14:03:27 GMT
+ * Generated on Wed, 13 Nov 2024 14:03:45 GMT
  */
 
 export const theme = {
@@ -64,12 +64,12 @@ export const theme = {
     "semiBold": "600"
   },
   "fontSize": {
-    "xxs": "0.75rem",
-    "xs": "0.875rem",
-    "s": "1rem",
-    "m": "1.1875rem",
-    "l": "1.3125rem",
-    "xl": "1.75rem"
+    "xs": "0.75rem",
+    "s": "0.875rem",
+    "m": "1rem",
+    "l": "1.1875rem",
+    "xl": "1.3125rem",
+    "xxl": "1.75rem"
   },
   "typography": {
     "title1": {

--- a/build/ts/index.web.ts
+++ b/build/ts/index.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 13 Nov 2024 14:03:45 GMT
+ * Generated on Wed, 27 Nov 2024 12:32:08 GMT
  */
 
 export const theme = {
@@ -67,9 +67,10 @@ export const theme = {
     "xs": "0.75rem",
     "s": "0.875rem",
     "m": "1rem",
-    "l": "1.1875rem",
-    "xl": "1.3125rem",
-    "xxl": "1.75rem"
+    "l": "1.0625rem",
+    "xl": "1.1875rem",
+    "xxl": "1.3125rem",
+    "xxxl": "1.75rem"
   },
   "typography": {
     "title1": {
@@ -92,7 +93,7 @@ export const theme = {
     },
     "title4": {
       "fontFamily": "Montserrat-Bold",
-      "fontSize": "1rem",
+      "fontSize": "1.0625rem",
       "lineHeight": "1.7rem",
       "color": "#161617"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "main": "design-tokens.json",
   "repository": "git@github.com:pass-culture/design-system.git",
   "private": true,

--- a/src/tokens/design-tokens.json
+++ b/src/tokens/design-tokens.json
@@ -181,18 +181,24 @@
       }
     },
     "l": {
-      "value": "19",
+      "value": "17",
       "attributes": {
         "category": "size"
       }
     },
     "xl": {
-      "value": "21",
+      "value": "19",
       "attributes": {
         "category": "size"
       }
     },
     "xxl": {
+      "value": "21",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxxl": {
       "value": "28",
       "attributes": {
         "category": "size"
@@ -205,7 +211,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.xxl}"
+        "value": "{fontSize.xxxl}"
       },
       "lineHeight": {
         "value": "{lineHeight.xxxl}"
@@ -219,7 +225,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.xl}"
+        "value": "{fontSize.xxl}"
       },
       "lineHeight": {
         "value": "{lineHeight.xxl}"
@@ -233,7 +239,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.l}"
+        "value": "{fontSize.xl}"
       },
       "lineHeight": {
         "value": "{lineHeight.xl}"
@@ -247,7 +253,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.m}"
+        "value": "{fontSize.l}"
       },
       "lineHeight": {
         "value": "{lineHeight.l}"

--- a/src/tokens/design-tokens.json
+++ b/src/tokens/design-tokens.json
@@ -162,37 +162,37 @@
     }
   },
   "fontSize": {
-    "xxs": {
+    "xs": {
       "value": "12",
       "attributes": {
         "category": "size"
       }
     },
-    "xs": {
+    "s": {
       "value": "14",
       "attributes": {
         "category": "size"
       }
     },
-    "s": {
+    "m": {
       "value": "16",
       "attributes": {
         "category": "size"
       }
     },
-    "m": {
+    "l": {
       "value": "19",
       "attributes": {
         "category": "size"
       }
     },
-    "l": {
+    "xl": {
       "value": "21",
       "attributes": {
         "category": "size"
       }
     },
-    "xl": {
+    "xxl": {
       "value": "28",
       "attributes": {
         "category": "size"
@@ -205,7 +205,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.xl}"
+        "value": "{fontSize.xxl}"
       },
       "lineHeight": {
         "value": "{lineHeight.xxxl}"
@@ -219,7 +219,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.l}"
+        "value": "{fontSize.xl}"
       },
       "lineHeight": {
         "value": "{lineHeight.xxl}"
@@ -233,7 +233,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.m}"
+        "value": "{fontSize.l}"
       },
       "lineHeight": {
         "value": "{lineHeight.xl}"
@@ -247,7 +247,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.s}"
+        "value": "{fontSize.m}"
       },
       "lineHeight": {
         "value": "{lineHeight.l}"
@@ -261,7 +261,7 @@
         "value": "{font.medium.family}"
       },
       "fontSize": {
-        "value": "{fontSize.s}"
+        "value": "{fontSize.m}"
       },
       "lineHeight": {
         "value": "{lineHeight.m}"
@@ -275,7 +275,7 @@
         "value": "{font.medium.family}"
       },
       "fontSize": {
-        "value": "{fontSize.xs}"
+        "value": "{fontSize.s}"
       },
       "lineHeight": {
         "value": "{lineHeight.s}"
@@ -289,7 +289,7 @@
         "value": "{font.medium.family}"
       },
       "fontSize": {
-        "value": "{fontSize.xxs}"
+        "value": "{fontSize.xs}"
       },
       "lineHeight": {
         "value": "{lineHeight.xs}"
@@ -303,7 +303,7 @@
         "value": "{font.semiBold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.s}"
+        "value": "{fontSize.m}"
       },
       "lineHeight": {
         "value": "{lineHeight.m}"
@@ -317,7 +317,7 @@
         "value": "{font.semiBold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.xs}"
+        "value": "{fontSize.s}"
       },
       "lineHeight": {
         "value": "{lineHeight.s}"
@@ -331,7 +331,7 @@
         "value": "{font.semiBold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.xxs}"
+        "value": "{fontSize.xs}"
       },
       "lineHeight": {
         "value": "{lineHeight.xs}"
@@ -345,7 +345,7 @@
         "value": "{font.mediumItalic.family}"
       },
       "fontSize": {
-        "value": "{fontSize.s}"
+        "value": "{fontSize.m}"
       },
       "lineHeight": {
         "value": "{lineHeight.m}"
@@ -359,7 +359,7 @@
         "value": "{font.semiBoldItalic.family}"
       },
       "fontSize": {
-        "value": "{fontSize.s}"
+        "value": "{fontSize.m}"
       },
       "lineHeight": {
         "value": "{lineHeight.m}"
@@ -373,7 +373,7 @@
         "value": "{font.bold.family}"
       },
       "fontSize": {
-        "value": "{fontSize.s}"
+        "value": "{fontSize.m}"
       },
       "lineHeight": {
         "value": "{lineHeight.m}"


### PR DESCRIPTION
[Lien du ticket JIRA](https://passculture.atlassian.net/browse/PC-32993)

**Objectif :**

**1er commit**
Décalage de l'échelle des font-sizes pour aller de "xs" à "xxl" à la place d'avoir "xxs" à "xl".
Comme ça, le body a la font-szie "m" (16px) et pas "s", ce qui était un peu bizarre.

A moins que l'app fasse appel directement à un token primitif, ce qui devrait pas être le cas, le changement ne devrait pas avoir d'effet!

**2e commit**
Corriger la font-size du title4 qui devrait être 17px et pas 16px en introduisant une font-size primitive supplémentaire.