### PR TITLE
Fix files included in tsconfig.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "design-tokens.json",
   "repository": "git@github.com:pass-culture/design-system.git",
   "private": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "declaration": true,
     "lib": ["es2022"]
   },
-  "include": ["build/ts/*", "src/**/*.ts"]
+  "include": ["build/**/*.ts", "src/**/*.ts"]
 }


### PR DESCRIPTION
Le `dist` n'était plus généré car le tsconfig inclut des fichiers .ts dans un dossier qui n'existe plus sur la nouvelle architecture.