### PR TITLE
Bsr css selector

### DIFF
--- a/build/global/font-faces.css
+++ b/build/global/font-faces.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
 

--- a/build/global/font-preloads.ts
+++ b/build/global/font-preloads.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
 

--- a/build/jeune/index.dark.mobile.ts
+++ b/build/jeune/index.dark.mobile.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:23 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
 export const theme = {

--- a/build/jeune/index.dark.web.ts
+++ b/build/jeune/index.dark.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
 export const theme = {

--- a/build/jeune/index.light.mobile.ts
+++ b/build/jeune/index.light.mobile.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
 export const theme = {

--- a/build/jeune/index.light.web.ts
+++ b/build/jeune/index.light.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
 export const theme = {

--- a/build/pro/index.dark.web.ts
+++ b/build/pro/index.dark.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
 export const theme = {

--- a/build/pro/index.light.web.ts
+++ b/build/pro/index.light.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
 export const theme = {

--- a/build/pro/variables-dark.css
+++ b/build/pro/variables-dark.css
@@ -1,9 +1,9 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
-:root {
+:root[data-theme="dark"] {
   --color-text-default: #ffffff;
   --color-text-subtle: #f1f1f4;
   --color-text-error: #f8b2c0;

--- a/build/pro/variables-light.css
+++ b/build/pro/variables-light.css
@@ -1,9 +1,9 @@
 /**
  * Do not edit directly
- * Generated on Fri, 07 Feb 2025 09:51:22 GMT
+ * Generated on Mon, 10 Feb 2025 16:43:17 GMT
  */
 
-:root {
+:root[data-theme="light"] {
   --color-text-default: #161617;
   --color-text-subtle: #696a6f;
   --color-text-error: #b60025;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "design-tokens.json",
   "repository": "git@github.com:pass-culture/design-system.git",
   "private": true,

--- a/src/configs/formatters/getWebCssConfig.ts
+++ b/src/configs/formatters/getWebCssConfig.ts
@@ -22,6 +22,9 @@ export const getWebCssConfig: ConfigFormatter = (sd, brand, theme) => {
             destination: `variables-${theme}.css`,
             format: 'css/variables',
             filter: designTokenFilter,
+            options: {
+              selector: `[data-theme="${theme}"]`,
+            },
           },
         ],
       },


### PR DESCRIPTION
Les fichiers de variables css générés étant appliqué sur `:root` par défaut, c'est impossible d'importer un ensemble de variables ou l'autre en fonction d'un sélecteur parent. J'ai ajouté un paramètre pour pouvoir directement importer les fichiers dans l'app pro.