### PR TITLE
Update typos tokens structure

### DIFF
--- a/build/global/font-faces.css
+++ b/build/global/font-faces.css
@@ -1,50 +1,45 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 
 @font-face {
- font-family: "Montserrat-Bold";
- font-style: "normal";
- font-weight: "700";
- src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff) format('woff2');
- font-display: "swap";
- unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;";
-}
-
-@font-face {
- font-family: "Montserrat-SemiBold";
- font-style: "normal";
- font-weight: "600";
- src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff) format('woff2');
- font-display: "swap";
- unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;";
-}
-
-@font-face {
- font-family: "Montserrat-SemiBoldItalic";
- font-style: "italic";
- font-weight: "600";
- src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff) format('woff2');
- font-display: "swap";
- unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;";
-}
-
-@font-face {
  font-family: "Montserrat-Medium";
  font-style: "normal";
- font-weight: "500";
- src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff) format('woff2');
+ src: url(https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXp-p7K4KLg.woff2) format('woff2');
  font-display: "swap";
- unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;";
+ unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD";
 }
 
 @font-face {
  font-family: "Montserrat-MediumItalic";
  font-style: "italic";
- font-weight: "500";
- src: url(https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff) format('woff2');
+ src: url(https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0ppC8MLnbtg.woff2) format('woff2');
  font-display: "swap";
- unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;";
+ unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD";
+}
+
+@font-face {
+ font-family: "Montserrat-SemiBold";
+ font-style: "normal";
+ src: url(https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXp-p7K4KLg.woff2) format('woff2');
+ font-display: "swap";
+ unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD";
+}
+
+@font-face {
+ font-family: "Montserrat-SemiBoldItalic";
+ font-style: "italic";
+ src: url(https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0ppC8MLnbtg.woff2) format('woff2');
+ font-display: "swap";
+ unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD";
+}
+
+@font-face {
+ font-family: "Montserrat-Bold";
+ font-style: "normal";
+ src: url(https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXp-p7K4KLg.woff2) format('woff2');
+ font-display: "swap";
+ unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD";
 }

--- a/build/global/font-preloads.ts
+++ b/build/global/font-preloads.ts
@@ -1,12 +1,12 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 
 export const fontPreloads =
-`<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff" as="font" type="font/woff2" crossorigin/>
-<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff" as="font" type="font/woff2" crossorigin/>
-<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff" as="font" type="font/woff2" crossorigin/>
-<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff" as="font" type="font/woff2" crossorigin/>
-<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff" as="font" type="font/woff2" crossorigin/>`
+`<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXp-p7K4KLg.woff2" as="font" type="font/woff2" crossorigin/>
+<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0ppC8MLnbtg.woff2" as="font" type="font/woff2" crossorigin/>
+<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXp-p7K4KLg.woff2" as="font" type="font/woff2" crossorigin/>
+<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0ppC8MLnbtg.woff2" as="font" type="font/woff2" crossorigin/>
+<link rel="preload" href="https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXp-p7K4KLg.woff2" as="font" type="font/woff2" crossorigin/>`

--- a/build/jeune/index.dark.mobile.ts
+++ b/build/jeune/index.dark.mobile.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 export const theme = {
@@ -66,48 +66,6 @@ export const theme = {
     "color": {
       "default": "#90949d",
       "subtle": "#696a6f"
-    }
-  },
-  "font": {
-    "bold": {
-      "family": "Montserrat-Bold",
-      "weight": "700",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBold": {
-      "family": "Montserrat-SemiBold",
-      "weight": "600",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBoldItalic": {
-      "family": "Montserrat-SemiBoldItalic",
-      "weight": "600",
-      "display": "swap",
-      "style": "italic",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "medium": {
-      "family": "Montserrat-Medium",
-      "weight": "500",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "mediumItalic": {
-      "family": "Montserrat-MediumItalic",
-      "weight": "500",
-      "style": "italic",
-      "display": "swap",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     }
   },
   "typography": {

--- a/build/jeune/index.dark.web.ts
+++ b/build/jeune/index.dark.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 export const theme = {
@@ -66,48 +66,6 @@ export const theme = {
     "color": {
       "default": "#90949d",
       "subtle": "#696a6f"
-    }
-  },
-  "font": {
-    "bold": {
-      "family": "Montserrat-Bold",
-      "weight": "700",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBold": {
-      "family": "Montserrat-SemiBold",
-      "weight": "600",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBoldItalic": {
-      "family": "Montserrat-SemiBoldItalic",
-      "weight": "600",
-      "display": "swap",
-      "style": "italic",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "medium": {
-      "family": "Montserrat-Medium",
-      "weight": "500",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "mediumItalic": {
-      "family": "Montserrat-MediumItalic",
-      "weight": "500",
-      "style": "italic",
-      "display": "swap",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     }
   },
   "typography": {

--- a/build/jeune/index.light.mobile.ts
+++ b/build/jeune/index.light.mobile.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 export const theme = {
@@ -66,48 +66,6 @@ export const theme = {
     "color": {
       "default": "#90949d",
       "subtle": "#cbcdd2"
-    }
-  },
-  "font": {
-    "bold": {
-      "family": "Montserrat-Bold",
-      "weight": "700",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBold": {
-      "family": "Montserrat-SemiBold",
-      "weight": "600",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBoldItalic": {
-      "family": "Montserrat-SemiBoldItalic",
-      "weight": "600",
-      "display": "swap",
-      "style": "italic",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "medium": {
-      "family": "Montserrat-Medium",
-      "weight": "500",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "mediumItalic": {
-      "family": "Montserrat-MediumItalic",
-      "weight": "500",
-      "style": "italic",
-      "display": "swap",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     }
   },
   "typography": {

--- a/build/jeune/index.light.web.ts
+++ b/build/jeune/index.light.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 export const theme = {
@@ -66,48 +66,6 @@ export const theme = {
     "color": {
       "default": "#90949d",
       "subtle": "#cbcdd2"
-    }
-  },
-  "font": {
-    "bold": {
-      "family": "Montserrat-Bold",
-      "weight": "700",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBold": {
-      "family": "Montserrat-SemiBold",
-      "weight": "600",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBoldItalic": {
-      "family": "Montserrat-SemiBoldItalic",
-      "weight": "600",
-      "display": "swap",
-      "style": "italic",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "medium": {
-      "family": "Montserrat-Medium",
-      "weight": "500",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "mediumItalic": {
-      "family": "Montserrat-MediumItalic",
-      "weight": "500",
-      "style": "italic",
-      "display": "swap",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     }
   },
   "typography": {

--- a/build/pro/index.dark.web.ts
+++ b/build/pro/index.dark.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 export const theme = {
@@ -66,48 +66,6 @@ export const theme = {
     "color": {
       "default": "#90949d",
       "subtle": "#696a6f"
-    }
-  },
-  "font": {
-    "bold": {
-      "family": "Montserrat-Bold",
-      "weight": "700",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBold": {
-      "family": "Montserrat-SemiBold",
-      "weight": "600",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBoldItalic": {
-      "family": "Montserrat-SemiBoldItalic",
-      "weight": "600",
-      "display": "swap",
-      "style": "italic",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "medium": {
-      "family": "Montserrat-Medium",
-      "weight": "500",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "mediumItalic": {
-      "family": "Montserrat-MediumItalic",
-      "weight": "500",
-      "style": "italic",
-      "display": "swap",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     }
   },
   "typography": {

--- a/build/pro/index.light.web.ts
+++ b/build/pro/index.light.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 export const theme = {
@@ -66,48 +66,6 @@ export const theme = {
     "color": {
       "default": "#90949d",
       "subtle": "#cbcdd2"
-    }
-  },
-  "font": {
-    "bold": {
-      "family": "Montserrat-Bold",
-      "weight": "700",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBold": {
-      "family": "Montserrat-SemiBold",
-      "weight": "600",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "semiBoldItalic": {
-      "family": "Montserrat-SemiBoldItalic",
-      "weight": "600",
-      "display": "swap",
-      "style": "italic",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "medium": {
-      "family": "Montserrat-Medium",
-      "weight": "500",
-      "display": "swap",
-      "style": "normal",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-    },
-    "mediumItalic": {
-      "family": "Montserrat-MediumItalic",
-      "weight": "500",
-      "style": "italic",
-      "display": "swap",
-      "src": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff",
-      "unicode-range": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
     }
   },
   "typography": {

--- a/build/pro/variables-dark.css
+++ b/build/pro/variables-dark.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 [data-theme="dark"] {
@@ -52,36 +52,6 @@
   --color-icon-locked: #ffffff;
   --separator-color-default: #90949d;
   --separator-color-subtle: #696a6f;
-  --font-bold-family: Montserrat-Bold;
-  --font-bold-weight: 700;
-  --font-bold-display: swap;
-  --font-bold-style: normal;
-  --font-bold-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff;
-  --font-bold-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-semi-bold-family: Montserrat-SemiBold;
-  --font-semi-bold-weight: 600;
-  --font-semi-bold-display: swap;
-  --font-semi-bold-style: normal;
-  --font-semi-bold-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff;
-  --font-semi-bold-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-semi-bold-italic-family: Montserrat-SemiBoldItalic;
-  --font-semi-bold-italic-weight: 600;
-  --font-semi-bold-italic-display: swap;
-  --font-semi-bold-italic-style: italic;
-  --font-semi-bold-italic-src: https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff;
-  --font-semi-bold-italic-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-medium-family: Montserrat-Medium;
-  --font-medium-weight: 500;
-  --font-medium-display: swap;
-  --font-medium-style: normal;
-  --font-medium-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff;
-  --font-medium-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-medium-italic-family: Montserrat-MediumItalic;
-  --font-medium-italic-weight: 500;
-  --font-medium-italic-style: italic;
-  --font-medium-italic-display: swap;
-  --font-medium-italic-src: https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff;
-  --font-medium-italic-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
   --typography-title1-font-family: Montserrat-Bold;
   --typography-title1-font-size: 1.75rem;
   --typography-title1-line-height: 2.8rem;

--- a/build/pro/variables-light.css
+++ b/build/pro/variables-light.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 26 Mar 2025 16:07:52 GMT
+ * Generated on Thu, 27 Mar 2025 13:12:14 GMT
  */
 
 [data-theme="light"] {
@@ -52,36 +52,6 @@
   --color-icon-locked: #ffffff;
   --separator-color-default: #90949d;
   --separator-color-subtle: #cbcdd2;
-  --font-bold-family: Montserrat-Bold;
-  --font-bold-weight: 700;
-  --font-bold-display: swap;
-  --font-bold-style: normal;
-  --font-bold-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff;
-  --font-bold-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-semi-bold-family: Montserrat-SemiBold;
-  --font-semi-bold-weight: 600;
-  --font-semi-bold-display: swap;
-  --font-semi-bold-style: normal;
-  --font-semi-bold-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff;
-  --font-semi-bold-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-semi-bold-italic-family: Montserrat-SemiBoldItalic;
-  --font-semi-bold-italic-weight: 600;
-  --font-semi-bold-italic-display: swap;
-  --font-semi-bold-italic-style: italic;
-  --font-semi-bold-italic-src: https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff;
-  --font-semi-bold-italic-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-medium-family: Montserrat-Medium;
-  --font-medium-weight: 500;
-  --font-medium-display: swap;
-  --font-medium-style: normal;
-  --font-medium-src: https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff;
-  --font-medium-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
-  --font-medium-italic-family: Montserrat-MediumItalic;
-  --font-medium-italic-weight: 500;
-  --font-medium-italic-style: italic;
-  --font-medium-italic-display: swap;
-  --font-medium-italic-src: https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff;
-  --font-medium-italic-unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;;
   --typography-title1-font-family: Montserrat-Bold;
   --typography-title1-font-size: 1.75rem;
   --typography-title1-line-height: 2.8rem;

--- a/src/configs/formatters/getTypoConfig.ts
+++ b/src/configs/formatters/getTypoConfig.ts
@@ -1,17 +1,16 @@
-import { TransformedToken, TransformedTokens } from 'style-dictionary'
+import { TransformedToken } from 'style-dictionary'
 import { FormatFn } from 'style-dictionary/types'
 import { ConfigFormatter } from '../../types'
-import { fileHeader, minifyDictionary } from 'style-dictionary/utils'
+import { fileHeader } from 'style-dictionary/utils'
 
-function createFontFace(token: TransformedTokens | TransformedToken) {
+function createFontFace(name: TransformedToken, url: TransformedToken) {
   return [
     '@font-face {',
-    ` font-family: "${token.family}";`,
-    token.style ? ` font-style: "${token.style}";` : '',
-    token.weight ? ` font-weight: "${token.weight}";` : '',
-    ` src: url(${token.src}) format('woff2');`,
+    ` font-family: "${name.value}";`,
+    ` font-style: "${name.value.includes('Italic') ? 'italic' : 'normal'}";`,
+    ` src: url(${url.value}) format('woff2');`,
     ` font-display: "swap";`,
-    ` unicode-range: "${token['unicode-range']}";`,
+    ` unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD";`,
     '}',
   ]
     .filter(Boolean)
@@ -19,22 +18,23 @@ function createFontFace(token: TransformedTokens | TransformedToken) {
 }
 
 const sdFontFacesFormatter: FormatFn = async ({ dictionary, file }) => {
-  const fontFacesTokens =
-    (minifyDictionary(dictionary.tokens) as typeof dictionary.tokens)['font'] ?? {}
+  const fonts = Object.entries(dictionary.tokens.fontFamily || {}).map(([key, val]) =>
+    createFontFace(val.name, val.url)
+  )
 
   return `${await fileHeader({
     file,
     formatting: {
       fileHeaderTimestamp: true,
     },
-  })}\n${Object.values(fontFacesTokens).map(createFontFace).join('\n\n')}`
+  })}\n${fonts.join('\n\n')}`
 }
 
 const sdFontPreloadsFormatter: FormatFn = async ({ dictionary, file }) => {
-  const fontTokens = (minifyDictionary(dictionary.tokens) as typeof dictionary.tokens)['font'] ?? {}
+  const fontsUrls = Object.values(dictionary.tokens.fontFamily || {}).map((font) => font.url.value)
 
-  function createPreload(token: TransformedTokens | TransformedToken) {
-    return `<link rel="preload" href="${token.src}" as="font" type="font/woff2" crossorigin/>`
+  function createPreload(url: string) {
+    return `<link rel="preload" href="${url}" as="font" type="font/woff2" crossorigin/>`
   }
 
   return `${await fileHeader({
@@ -42,7 +42,7 @@ const sdFontPreloadsFormatter: FormatFn = async ({ dictionary, file }) => {
     formatting: {
       fileHeaderTimestamp: true,
     },
-  })}\nexport const fontPreloads =\n\`${Object.values(fontTokens).map(createPreload).join('\n')}\``
+  })}\nexport const fontPreloads =\n\`${fontsUrls.map(createPreload).join('\n')}\``
 }
 
 export const getTypoConfig: ConfigFormatter = (sd) => {

--- a/src/tokens/global/typography/primitive.json
+++ b/src/tokens/global/typography/primitive.json
@@ -69,5 +69,47 @@
       "value": "28",
       "type": "dimension"
     }
+  },
+  "fontFamily": {
+    "medium": {
+      "name": {
+        "value": "Montserrat-Medium"
+      },
+      "url": {
+        "value": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXp-p7K4KLg.woff2"
+      }
+    },
+    "mediumItalic": {
+      "name": {
+        "value": "Montserrat-MediumItalic"
+      },
+      "url": {
+        "value": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0ppC8MLnbtg.woff2"
+      }
+    },
+    "semiBold": {
+      "name": {
+        "value": "Montserrat-SemiBold"
+      },
+      "url": {
+        "value": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXp-p7K4KLg.woff2"
+      }
+    },
+    "semiBoldItalic": {
+      "name": {
+        "value": "Montserrat-SemiBoldItalic"
+      },
+      "url": {
+        "value": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0ppC8MLnbtg.woff2"
+      }
+    },
+    "bold": {
+      "name": {
+        "value": "Montserrat-Bold"
+      },
+      "url": {
+        "value": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXp-p7K4KLg.woff2"
+      }
+    }
   }
 }

--- a/src/tokens/global/typography/semantic.json
+++ b/src/tokens/global/typography/semantic.json
@@ -1,110 +1,8 @@
 {
-  "font": {
-    "bold": {
-      "family": {
-        "value": "Montserrat-Bold"
-      },
-      "weight": {
-        "value": "{fontWeight.bold}"
-      },
-      "display": {
-        "value": "swap"
-      },
-      "style": {
-        "value": "normal"
-      },
-      "src": {
-        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM73w5aXx-p7K4KLg.woff"
-      },
-      "unicode-range": {
-        "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-      }
-    },
-    "semiBold": {
-      "family": {
-        "value": "Montserrat-SemiBold"
-      },
-      "weight": {
-        "value": "{fontWeight.semiBold}"
-      },
-      "display": {
-        "value": "swap"
-      },
-      "style": {
-        "value": "normal"
-      },
-      "src": {
-        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXx-p7K4KLg.woff"
-      },
-      "unicode-range": {
-        "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-      }
-    },
-    "semiBoldItalic": {
-      "family": {
-        "value": "Montserrat-SemiBoldItalic"
-      },
-      "weight": {
-        "value": "{fontWeight.semiBold}"
-      },
-      "display": {
-        "value": "swap"
-      },
-      "style": {
-        "value": "italic"
-      },
-      "src": {
-        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6WXh0oJC8MLnbtg.woff"
-      },
-      "unicode-range": {
-        "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-      }
-    },
-    "medium": {
-      "family": {
-        "value": "Montserrat-Medium"
-      },
-      "weight": {
-        "value": "{fontWeight.medium}"
-      },
-      "display": {
-        "value": "swap"
-      },
-      "style": {
-        "value": "normal"
-      },
-      "src": {
-        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Hw5aXx-p7K4KLg.woff"
-      },
-      "unicode-range": {
-        "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-      }
-    },
-    "mediumItalic": {
-      "family": {
-        "value": "Montserrat-MediumItalic"
-      },
-      "weight": {
-        "value": "{fontWeight.medium}"
-      },
-      "style": {
-        "value": "italic"
-      },
-      "display": {
-        "value": "swap"
-      },
-      "src": {
-        "value": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9WXh0oJC8MLnbtg.woff"
-      },
-      "unicode-range": {
-        "value": "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;"
-      }
-    }
-  },
   "typography": {
     "title1": {
       "fontFamily": {
-        "value": "{font.bold.family}"
+        "value": "{fontFamily.bold.name}"
       },
       "fontSize": {
         "value": "{fontSize.xxxl}"
@@ -115,7 +13,7 @@
     },
     "title2": {
       "fontFamily": {
-        "value": "{font.bold.family}"
+        "value": "{fontFamily.bold.name}"
       },
       "fontSize": {
         "value": "{fontSize.xxl}"
@@ -126,7 +24,7 @@
     },
     "title3": {
       "fontFamily": {
-        "value": "{font.bold.family}"
+        "value": "{fontFamily.bold.name}"
       },
       "fontSize": {
         "value": "{fontSize.xl}"
@@ -137,7 +35,7 @@
     },
     "title4": {
       "fontFamily": {
-        "value": "{font.bold.family}"
+        "value": "{fontFamily.bold.name}"
       },
       "fontSize": {
         "value": "{fontSize.l}"
@@ -148,7 +46,7 @@
     },
     "body": {
       "fontFamily": {
-        "value": "{font.medium.family}"
+        "value": "{fontFamily.medium.name}"
       },
       "fontSize": {
         "value": "{fontSize.m}"
@@ -159,7 +57,7 @@
     },
     "bodyS": {
       "fontFamily": {
-        "value": "{font.medium.family}"
+        "value": "{fontFamily.medium.name}"
       },
       "fontSize": {
         "value": "{fontSize.s}"
@@ -170,7 +68,7 @@
     },
     "bodyXs": {
       "fontFamily": {
-        "value": "{font.medium.family}"
+        "value": "{fontFamily.medium.name}"
       },
       "fontSize": {
         "value": "{fontSize.xs}"
@@ -181,7 +79,7 @@
     },
     "bodyAccent": {
       "fontFamily": {
-        "value": "{font.semiBold.family}"
+        "value": "{fontFamily.semiBold.name}"
       },
       "fontSize": {
         "value": "{fontSize.m}"
@@ -192,7 +90,7 @@
     },
     "bodyAccentS": {
       "fontFamily": {
-        "value": "{font.semiBold.family}"
+        "value": "{fontFamily.semiBold.name}"
       },
       "fontSize": {
         "value": "{fontSize.s}"
@@ -203,7 +101,7 @@
     },
     "bodyAccentXs": {
       "fontFamily": {
-        "value": "{font.semiBold.family}"
+        "value": "{fontFamily.semiBold.name}"
       },
       "fontSize": {
         "value": "{fontSize.xs}"
@@ -214,7 +112,7 @@
     },
     "bodyItalic": {
       "fontFamily": {
-        "value": "{font.mediumItalic.family}"
+        "value": "{fontFamily.mediumItalic.name}"
       },
       "fontSize": {
         "value": "{fontSize.m}"
@@ -225,7 +123,7 @@
     },
     "bodyItalicAccent": {
       "fontFamily": {
-        "value": "{font.semiBoldItalic.family}"
+        "value": "{fontFamily.semiBoldItalic.name}"
       },
       "fontSize": {
         "value": "{fontSize.m}"
@@ -236,7 +134,7 @@
     },
     "button": {
       "fontFamily": {
-        "value": "{font.bold.family}"
+        "value": "{fontFamily.bold.name}"
       },
       "fontSize": {
         "value": "{fontSize.m}"


### PR DESCRIPTION
Pour aligner le fonctionnement des tokens de typos avec les tokens de couleur, cette PR retravaille la génération des typos.
- Suppression des tokens `fonts.[...]` de `typography/semantic.json`. La raison étant que ces tokens contiennent des valeurs brutes, et ne sont donc pas des tokens semantic. Ils servent à la génération des font-faces et font-preloads qui peuvent aussi bien être déduits de tokens primitifs.
- Création des tokens primitifs `font-family`.
- Adaptation du script de build des fichiers de typos pour se baser sur la `font-family` des tokens primitifs.

A noter que ça augmente la similitude entre le .json exporté de Figma -> zeroheight, mais Figma nous empêche de toute façon d'avoir un token `font-family` qui prenne des valeurs différentes pour Montserrat (ex: "Montserrat-Bold"), ce qui est nécessaire pour l'app mobile (@yleclercq-pass si tu confirmes :)).

Aussi Figma considère que les font-weight sont au format string "semi bold italic", ce qui est un pb (une font-weight devrait être un number, et ne devrait pas contenir le font-style).

Enfin, Figma ne permet pas de différencier les types de valeurs numériques (donc [pas conforme au w3c](https://tr.designtokens.org/format/)). Et ne permet pas non plus d'ajouter des attributs custom aux tokens.

Donc pour le moment les typos ne peuvent pas être synchronisées entre Figma et github.