### PR TITLE
Bsr update colors 2

### DIFF
--- a/build/global/font-faces.css
+++ b/build/global/font-faces.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 

--- a/build/global/font-faces.css
+++ b/build/global/font-faces.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 

--- a/build/global/font-preloads.ts
+++ b/build/global/font-preloads.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 

--- a/build/global/font-preloads.ts
+++ b/build/global/font-preloads.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 

--- a/build/jeune/index.dark.mobile.ts
+++ b/build/jeune/index.dark.mobile.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 export const theme = {
@@ -27,7 +27,12 @@ export const theme = {
       "focused": "#ffffff",
       "brandPrimary": "#ffa5c0",
       "brandPrimaryHover": "#f2497c",
-      "inverted": "#161617"
+      "inverted": "#161617",
+      "decorative01": "#ffeae2",
+      "decorative02": "#dcf3f8",
+      "decorative03": "#dbffea",
+      "decorative04": "#c1a3ff",
+      "decorative05": "#ffa5c0"
     },
     "outline": {
       "default": "#ffffff",
@@ -48,7 +53,12 @@ export const theme = {
       "locked": "#161617",
       "lockedBrandPrimary": "#eb0055",
       "lockedBrandSecondary": "#320096",
-      "inverted": "#ffffff"
+      "inverted": "#ffffff",
+      "decorative01": "#d63d00",
+      "decorative02": "#0e78b7",
+      "decorative03": "#0e8474",
+      "decorative04": "#25026c",
+      "decorative05": "#cb0659"
     },
     "icon": {
       "default": "#ffffff",
@@ -139,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#ffa5c0" | "#f2497c" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#700118" | "#09532d" | "#664900" | "#cb0659" | "#eb0055" | "#320096" | "#ffef63";
+export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#ffa5c0" | "#f2497c" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#700118" | "#09532d" | "#664900" | "#cb0659" | "#eb0055" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#25026c" | "#ffef63";
       

--- a/build/jeune/index.dark.mobile.ts
+++ b/build/jeune/index.dark.mobile.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 export const theme = {
@@ -41,7 +41,7 @@ export const theme = {
     },
     "background": {
       "default": "#161617",
-      "subtle": "#696a6f",
+      "subtle": "#232323",
       "disabled": "#696a6f",
       "error": "#700118",
       "success": "#09532d",
@@ -149,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#ffa5c0" | "#f2497c" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#700118" | "#09532d" | "#664900" | "#cb0659" | "#eb0055" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#25026c" | "#ffef63";
+export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#ffa5c0" | "#f2497c" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#232323" | "#700118" | "#09532d" | "#664900" | "#cb0659" | "#eb0055" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#25026c" | "#ffef63";
       

--- a/build/jeune/index.dark.web.ts
+++ b/build/jeune/index.dark.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 export const theme = {
@@ -27,7 +27,12 @@ export const theme = {
       "focused": "#ffffff",
       "brandPrimary": "#ffa5c0",
       "brandPrimaryHover": "#f2497c",
-      "inverted": "#161617"
+      "inverted": "#161617",
+      "decorative01": "#ffeae2",
+      "decorative02": "#dcf3f8",
+      "decorative03": "#dbffea",
+      "decorative04": "#c1a3ff",
+      "decorative05": "#ffa5c0"
     },
     "outline": {
       "default": "#ffffff",
@@ -48,7 +53,12 @@ export const theme = {
       "locked": "#161617",
       "lockedBrandPrimary": "#eb0055",
       "lockedBrandSecondary": "#320096",
-      "inverted": "#ffffff"
+      "inverted": "#ffffff",
+      "decorative01": "#d63d00",
+      "decorative02": "#0e78b7",
+      "decorative03": "#0e8474",
+      "decorative04": "#25026c",
+      "decorative05": "#cb0659"
     },
     "icon": {
       "default": "#ffffff",
@@ -139,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#ffa5c0" | "#f2497c" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#700118" | "#09532d" | "#664900" | "#cb0659" | "#eb0055" | "#320096" | "#ffef63";
+export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#ffa5c0" | "#f2497c" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#700118" | "#09532d" | "#664900" | "#cb0659" | "#eb0055" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#25026c" | "#ffef63";
       

--- a/build/jeune/index.dark.web.ts
+++ b/build/jeune/index.dark.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 export const theme = {
@@ -41,7 +41,7 @@ export const theme = {
     },
     "background": {
       "default": "#161617",
-      "subtle": "#696a6f",
+      "subtle": "#232323",
       "disabled": "#696a6f",
       "error": "#700118",
       "success": "#09532d",
@@ -149,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#ffa5c0" | "#f2497c" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#700118" | "#09532d" | "#664900" | "#cb0659" | "#eb0055" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#25026c" | "#ffef63";
+export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#ffa5c0" | "#f2497c" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#232323" | "#700118" | "#09532d" | "#664900" | "#cb0659" | "#eb0055" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#25026c" | "#ffef63";
       

--- a/build/jeune/index.light.mobile.ts
+++ b/build/jeune/index.light.mobile.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 export const theme = {

--- a/build/jeune/index.light.mobile.ts
+++ b/build/jeune/index.light.mobile.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 export const theme = {
@@ -27,7 +27,12 @@ export const theme = {
       "focused": "#161617",
       "brandPrimary": "#eb0055",
       "brandPrimaryHover": "#cb0659",
-      "inverted": "#ffffff"
+      "inverted": "#ffffff",
+      "decorative01": "#d63d00",
+      "decorative02": "#20c5e9",
+      "decorative03": "#0e8474",
+      "decorative04": "#320096",
+      "decorative05": "#eb0055"
     },
     "outline": {
       "default": "#161617",
@@ -48,7 +53,12 @@ export const theme = {
       "locked": "#161617",
       "lockedBrandPrimary": "#eb0055",
       "lockedBrandSecondary": "#320096",
-      "inverted": "#161617"
+      "inverted": "#161617",
+      "decorative01": "#ffeae2",
+      "decorative02": "#9be3f3",
+      "decorative03": "#94f0d6",
+      "decorative04": "#c1a3ff",
+      "decorative05": "#ffa5c0"
     },
     "icon": {
       "default": "#161617",
@@ -139,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#161617" | "#696a6f" | "#a20121" | "#15884f" | "#eb0055" | "#cb0659" | "#320096" | "#25026c" | "#ffffff" | "#90949d" | "#cbcdd2" | "#f1f1f4" | "#fdf4f6" | "#eaf8f0" | "#fff8df" | "#ffe0ea" | "#e1a605";
+export type ColorsType = "#161617" | "#696a6f" | "#a20121" | "#15884f" | "#eb0055" | "#cb0659" | "#320096" | "#25026c" | "#ffffff" | "#90949d" | "#cbcdd2" | "#f1f1f4" | "#d63d00" | "#20c5e9" | "#0e8474" | "#fdf4f6" | "#eaf8f0" | "#fff8df" | "#ffe0ea" | "#ffeae2" | "#9be3f3" | "#94f0d6" | "#c1a3ff" | "#ffa5c0" | "#e1a605";
       

--- a/build/jeune/index.light.web.ts
+++ b/build/jeune/index.light.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 export const theme = {

--- a/build/jeune/index.light.web.ts
+++ b/build/jeune/index.light.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 export const theme = {
@@ -27,7 +27,12 @@ export const theme = {
       "focused": "#161617",
       "brandPrimary": "#eb0055",
       "brandPrimaryHover": "#cb0659",
-      "inverted": "#ffffff"
+      "inverted": "#ffffff",
+      "decorative01": "#d63d00",
+      "decorative02": "#20c5e9",
+      "decorative03": "#0e8474",
+      "decorative04": "#320096",
+      "decorative05": "#eb0055"
     },
     "outline": {
       "default": "#161617",
@@ -48,7 +53,12 @@ export const theme = {
       "locked": "#161617",
       "lockedBrandPrimary": "#eb0055",
       "lockedBrandSecondary": "#320096",
-      "inverted": "#161617"
+      "inverted": "#161617",
+      "decorative01": "#ffeae2",
+      "decorative02": "#9be3f3",
+      "decorative03": "#94f0d6",
+      "decorative04": "#c1a3ff",
+      "decorative05": "#ffa5c0"
     },
     "icon": {
       "default": "#161617",
@@ -139,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#161617" | "#696a6f" | "#a20121" | "#15884f" | "#eb0055" | "#cb0659" | "#320096" | "#25026c" | "#ffffff" | "#90949d" | "#cbcdd2" | "#f1f1f4" | "#fdf4f6" | "#eaf8f0" | "#fff8df" | "#ffe0ea" | "#e1a605";
+export type ColorsType = "#161617" | "#696a6f" | "#a20121" | "#15884f" | "#eb0055" | "#cb0659" | "#320096" | "#25026c" | "#ffffff" | "#90949d" | "#cbcdd2" | "#f1f1f4" | "#d63d00" | "#20c5e9" | "#0e8474" | "#fdf4f6" | "#eaf8f0" | "#fff8df" | "#ffe0ea" | "#ffeae2" | "#9be3f3" | "#94f0d6" | "#c1a3ff" | "#ffa5c0" | "#e1a605";
       

--- a/build/pro/index.dark.web.ts
+++ b/build/pro/index.dark.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 export const theme = {
@@ -27,7 +27,12 @@ export const theme = {
       "focused": "#ffffff",
       "brandPrimary": "#c1a3ff",
       "brandPrimaryHover": "#6123df",
-      "inverted": "#161617"
+      "inverted": "#161617",
+      "decorative01": "#ffeae2",
+      "decorative02": "#dcf3f8",
+      "decorative03": "#dbffea",
+      "decorative04": "#c1a3ff",
+      "decorative05": "#ffa5c0"
     },
     "outline": {
       "default": "#ffffff",
@@ -48,7 +53,12 @@ export const theme = {
       "locked": "#161617",
       "lockedBrandPrimary": "#320096",
       "lockedBrandSecondary": "#320096",
-      "inverted": "#ffffff"
+      "inverted": "#ffffff",
+      "decorative01": "#d63d00",
+      "decorative02": "#0e78b7",
+      "decorative03": "#0e8474",
+      "decorative04": "#25026c",
+      "decorative05": "#cb0659"
     },
     "icon": {
       "default": "#ffffff",
@@ -139,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#700118" | "#09532d" | "#664900" | "#25026c" | "#320096" | "#ffef63";
+export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#ffa5c0" | "#700118" | "#09532d" | "#664900" | "#25026c" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#cb0659" | "#ffef63";
       

--- a/build/pro/index.dark.web.ts
+++ b/build/pro/index.dark.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 export const theme = {
@@ -41,7 +41,7 @@ export const theme = {
     },
     "background": {
       "default": "#161617",
-      "subtle": "#696a6f",
+      "subtle": "#232323",
       "disabled": "#696a6f",
       "error": "#700118",
       "success": "#09532d",
@@ -149,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#ffa5c0" | "#700118" | "#09532d" | "#664900" | "#25026c" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#cb0659" | "#ffef63";
+export type ColorsType = "#ffffff" | "#cbcdd2" | "#f83552" | "#f1f1f4" | "#2cbe6e" | "#c1a3ff" | "#6123df" | "#161617" | "#90949d" | "#696a6f" | "#ffeae2" | "#dcf3f8" | "#dbffea" | "#ffa5c0" | "#232323" | "#700118" | "#09532d" | "#664900" | "#25026c" | "#320096" | "#d63d00" | "#0e78b7" | "#0e8474" | "#cb0659" | "#ffef63";
       

--- a/build/pro/index.light.web.ts
+++ b/build/pro/index.light.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 export const theme = {

--- a/build/pro/index.light.web.ts
+++ b/build/pro/index.light.web.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 export const theme = {
@@ -27,7 +27,12 @@ export const theme = {
       "focused": "#161617",
       "brandPrimary": "#6123df",
       "brandPrimaryHover": "#320096",
-      "inverted": "#ffffff"
+      "inverted": "#ffffff",
+      "decorative01": "#d63d00",
+      "decorative02": "#20c5e9",
+      "decorative03": "#0e8474",
+      "decorative04": "#320096",
+      "decorative05": "#eb0055"
     },
     "outline": {
       "default": "#161617",
@@ -48,7 +53,12 @@ export const theme = {
       "locked": "#161617",
       "lockedBrandPrimary": "#6123df",
       "lockedBrandSecondary": "#6123df",
-      "inverted": "#161617"
+      "inverted": "#161617",
+      "decorative01": "#ffeae2",
+      "decorative02": "#9be3f3",
+      "decorative03": "#94f0d6",
+      "decorative04": "#c1a3ff",
+      "decorative05": "#ffa5c0"
     },
     "icon": {
       "default": "#161617",
@@ -139,5 +149,5 @@ export const theme = {
   }
 } as const;
 
-export type ColorsType = "#161617" | "#696a6f" | "#a20121" | "#15884f" | "#6123df" | "#320096" | "#25026c" | "#ffffff" | "#90949d" | "#cbcdd2" | "#f1f1f4" | "#fdf4f6" | "#eaf8f0" | "#fff8df" | "#f3edff" | "#e1a605";
+export type ColorsType = "#161617" | "#696a6f" | "#a20121" | "#15884f" | "#6123df" | "#320096" | "#25026c" | "#ffffff" | "#90949d" | "#cbcdd2" | "#f1f1f4" | "#d63d00" | "#20c5e9" | "#0e8474" | "#eb0055" | "#fdf4f6" | "#eaf8f0" | "#fff8df" | "#f3edff" | "#ffeae2" | "#9be3f3" | "#94f0d6" | "#c1a3ff" | "#ffa5c0" | "#e1a605";
       

--- a/build/pro/variables-dark.css
+++ b/build/pro/variables-dark.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 [data-theme="dark"] {
@@ -33,7 +33,7 @@
   --color-outline-error: #f83552;
   --color-outline-inverted: #161617;
   --color-background-default: #161617;
-  --color-background-subtle: #696a6f;
+  --color-background-subtle: #232323;
   --color-background-disabled: #696a6f;
   --color-background-error: #700118;
   --color-background-success: #09532d;

--- a/build/pro/variables-dark.css
+++ b/build/pro/variables-dark.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 [data-theme="dark"] {
@@ -24,6 +24,11 @@
   --color-border-brand-primary: #c1a3ff;
   --color-border-brand-primary-hover: #6123df;
   --color-border-inverted: #161617;
+  --color-border-decorative01: #ffeae2;
+  --color-border-decorative02: #dcf3f8;
+  --color-border-decorative03: #dbffea;
+  --color-border-decorative04: #c1a3ff;
+  --color-border-decorative05: #ffa5c0;
   --color-outline-default: #ffffff;
   --color-outline-error: #f83552;
   --color-outline-inverted: #161617;
@@ -41,6 +46,11 @@
   --color-background-locked-brand-primary: #320096;
   --color-background-locked-brand-secondary: #320096;
   --color-background-inverted: #ffffff;
+  --color-background-decorative01: #d63d00;
+  --color-background-decorative02: #0e78b7;
+  --color-background-decorative03: #0e8474;
+  --color-background-decorative04: #25026c;
+  --color-background-decorative05: #cb0659;
   --color-icon-default: #ffffff;
   --color-icon-disabled: #cbcdd2;
   --color-icon-subtle: #cbcdd2;

--- a/build/pro/variables-light.css
+++ b/build/pro/variables-light.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 13:05:33 GMT
+ * Generated on Thu, 24 Apr 2025 15:05:32 GMT
  */
 
 [data-theme="light"] {
@@ -24,6 +24,11 @@
   --color-border-brand-primary: #6123df;
   --color-border-brand-primary-hover: #320096;
   --color-border-inverted: #ffffff;
+  --color-border-decorative01: #d63d00;
+  --color-border-decorative02: #20c5e9;
+  --color-border-decorative03: #0e8474;
+  --color-border-decorative04: #320096;
+  --color-border-decorative05: #eb0055;
   --color-outline-default: #161617;
   --color-outline-error: #a20121;
   --color-outline-inverted: #ffffff;
@@ -41,6 +46,11 @@
   --color-background-locked-brand-primary: #6123df;
   --color-background-locked-brand-secondary: #6123df;
   --color-background-inverted: #161617;
+  --color-background-decorative01: #ffeae2;
+  --color-background-decorative02: #9be3f3;
+  --color-background-decorative03: #94f0d6;
+  --color-background-decorative04: #c1a3ff;
+  --color-background-decorative05: #ffa5c0;
   --color-icon-default: #161617;
   --color-icon-disabled: #696a6f;
   --color-icon-subtle: #696a6f;

--- a/build/pro/variables-light.css
+++ b/build/pro/variables-light.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 24 Apr 2025 15:05:32 GMT
+ * Generated on Thu, 24 Apr 2025 15:09:33 GMT
  */
 
 [data-theme="light"] {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "design-tokens.json",
   "repository": "git@github.com:pass-culture/design-system.git",
   "private": true,

--- a/src/tokens/global/colors/primitive.json
+++ b/src/tokens/global/colors/primitive.json
@@ -22,6 +22,10 @@
         "type": "color"
       },
       "500": {
+        "value": "#232323",
+        "type": "color"
+      },
+      "600": {
         "value": "#161617",
         "type": "color"
       }

--- a/src/tokens/global/colors/semantic.json
+++ b/src/tokens/global/colors/semantic.json
@@ -62,6 +62,21 @@
       },
       "inverted": {
         "value": "{color.grey.0}"
+      },
+      "decorative01": {
+        "value": "{color.orange.600}"
+      },
+      "decorative02": {
+        "value": "{color.blue.500}"
+      },
+      "decorative03": {
+        "value": "{color.mintgreen.600}"
+      },
+      "decorative04": {
+        "value": "{color.purple.500}"
+      },
+      "decorative05": {
+        "value": "{color.pink.500}"
       }
     },
     "outline": {
@@ -117,6 +132,21 @@
       },
       "inverted": {
         "value": "{color.grey.500}"
+      },
+      "decorative01": {
+        "value": "{color.orange.300}"
+      },
+      "decorative02": {
+        "value": "{color.blue.400}"
+      },
+      "decorative03": {
+        "value": "{color.mintgreen.400}"
+      },
+      "decorative04": {
+        "value": "{color.purple.300}"
+      },
+      "decorative05": {
+        "value": "{color.pink.300}"
       }
     },
     "icon": {

--- a/src/tokens/global/colors/semantic.json
+++ b/src/tokens/global/colors/semantic.json
@@ -2,7 +2,7 @@
   "color": {
     "text": {
       "default": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "subtle": {
         "value": "{color.grey.400}"
@@ -49,10 +49,10 @@
         "value": "{color.red.500}"
       },
       "selected": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "focused": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "brandPrimary": {
         "value": "{color.pink.500}"
@@ -81,7 +81,7 @@
     },
     "outline": {
       "default": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "error": {
         "value": "{color.red.500}"
@@ -122,7 +122,7 @@
         "value": "{color.pink.200}"
       },
       "locked": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "lockedBrandPrimary": {
         "value": "{color.pink.500}"
@@ -131,7 +131,7 @@
         "value": "{color.purple.500}"
       },
       "inverted": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "decorative01": {
         "value": "{color.orange.300}"
@@ -151,7 +151,7 @@
     },
     "icon": {
       "default": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "disabled": {
         "value": "{color.grey.400}"

--- a/src/tokens/themes/dark.json
+++ b/src/tokens/themes/dark.json
@@ -29,7 +29,7 @@
         "value": "{color.purple.400}"
       },
       "inverted": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "locked": {
         "value": "{color.grey.0}"
@@ -61,7 +61,7 @@
         "value": "{color.grey.0}"
       },
       "inverted": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "decorative01": {
         "value": "{color.orange.300}"
@@ -81,10 +81,10 @@
     },
     "background": {
       "default": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "subtle": {
-        "value": "{color.grey.400}"
+        "value": "{color.grey.500}"
       },
       "disabled": {
         "value": "{color.grey.400}"
@@ -111,7 +111,7 @@
         "value": "{color.pink.600}"
       },
       "locked": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "lockedBrandPrimary": {
         "value": "{color.pink.500}"
@@ -146,7 +146,7 @@
         "value": "{color.red.400}"
       },
       "inverted": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       }
     },
     "icon": {
@@ -178,7 +178,7 @@
         "value": "{color.pink.400}"
       },
       "inverted": {
-        "value": "{color.grey.500}"
+        "value": "{color.grey.600}"
       },
       "locked": {
         "value": "{color.grey.0}"

--- a/src/tokens/themes/dark.json
+++ b/src/tokens/themes/dark.json
@@ -62,6 +62,21 @@
       },
       "inverted": {
         "value": "{color.grey.500}"
+      },
+      "decorative01": {
+        "value": "{color.orange.300}"
+      },
+      "decorative02": {
+        "value": "{color.blue.300}"
+      },
+      "decorative03": {
+        "value": "{color.mintgreen.300}"
+      },
+      "decorative04": {
+        "value": "{color.purple.300}"
+      },
+      "decorative05": {
+        "value": "{color.pink.300}"
       }
     },
     "background": {
@@ -106,6 +121,21 @@
       },
       "inverted": {
         "value": "{color.grey.0}"
+      },
+      "decorative01": {
+        "value": "{color.orange.600}"
+      },
+      "decorative02": {
+        "value": "{color.blue.600}"
+      },
+      "decorative03": {
+        "value": "{color.mintgreen.600}"
+      },
+      "decorative04": {
+        "value": "{color.purple.600}"
+      },
+      "decorative05": {
+        "value": "{color.pink.600}"
       }
     },
     "outline": {


### PR DESCRIPTION
- ajout des couleurs décoratives (et de leur équivalent dark)
- ajout d'une teinte de gris (`grey.500` devient `grey.600` et le nouveau `grey.500` est `#232323`)
- utilisation du nouveau gris pour le `color-background-subtle` en mode sombre