### PR TITLE
(PC-42210) feat(tokens): add new tokens images size

### DIFF
--- a/src/tokens/global/size/primitive.json
+++ b/src/tokens/global/size/primitive.json
@@ -48,8 +48,20 @@
       "value": 72,
       "type": "dimension"
     },
+     "1300": {
+      "value": 80,
+      "type": "dimension"
+    },
     "1500": {
       "value": 96,
+      "type": "dimension"
+    },
+     "2100": {
+      "value": 144,
+      "type": "dimension"
+    },
+     "2500": {
+      "value": 176,
       "type": "dimension"
     },
     "2800": {

--- a/src/tokens/global/size/semantic.json
+++ b/src/tokens/global/size/semantic.json
@@ -67,11 +67,23 @@
       }
     },
     "image": {
-      "s": {
+      "xxs": {
         "value": "{size.1000}"
       },
-      "m": {
+      "xs": {
         "value": "{size.1200}"
+      },
+      "s": {
+        "value": "{size.1300}"
+      },
+      "m": {
+        "value": "{size.1500}"
+      },
+      "l": {
+        "value": "{size.2100}"
+      },
+      "xl": {
+        "value": "{size.2500}"
       }
     },
     "illustration": {


### PR DESCRIPTION
Ajout de nouveaux tokens de taille pour compléter l’échelle primitive et enrichir les tailles sémantiques d’image.

Tokens primitifs ajoutés :
- `size.1300` = `80`
- `size.2100` = `144`
- `size.2500` = `176`

Tokens sémantiques mis à jour :
- Extension de `size.image` avec les tailles `xxs`, `xs`, `s`, `m`, `l`, `xl`
- Remapping des anciennes tailles image pour garder une progression plus complète et cohérente :
  - `image.xxs` -> `{size.1000}`
  - `image.xs` -> `{size.1200}`
  - `image.s` -> `{size.1300}`
  - `image.m` -> `{size.1500}`
  - `image.l` -> `{size.2100}`
  - `image.xl` -> `{size.2500}`