### PR TITLE
(PC-42701) add scene club token and change proEdito value

### DIFF
--- a/src/tokens/global/colors/semantic.json
+++ b/src/tokens/global/colors/semantic.json
@@ -197,6 +197,9 @@
         "value": "{color.pink.200}"
       },
       "proEdito": {
+        "value": "{color.green.200}"
+      },
+      "sceneClub": {
         "value": "{color.orange.300}"
       },
       "overlay": {
@@ -283,6 +286,9 @@
         "value": "{color.pink.600}"
       },
       "proEdito": {
+        "value": "{color.green.600}"
+      },
+      "sceneClub": {
         "value": "{color.orange.600}"
       },
       "danger": {

--- a/src/tokens/themes/dark.json
+++ b/src/tokens/themes/dark.json
@@ -186,6 +186,9 @@
         "value": "{color.pink.600}"
       },
       "proEdito": {
+        "value": "{color.green.600}"
+      },
+      "sceneClub": {
         "value": "{color.orange.600}"
       },
       "overlay": {
@@ -283,6 +286,9 @@
         "value": "{color.pink.500}"
       },
       "proEdito": {
+        "value": "{color.green.500}"
+      },
+      "sceneClub": {
         "value": "{color.orange.500}"
       },
       "danger": {


### PR DESCRIPTION
## Mappings

### Light / global

| Token | Valeur |
| --- | --- |
| `background.proEdito` | `green.200` |
| `background.sceneClub` | `orange.300` |
| `icon.proEdito` | `green.600` |
| `icon.sceneClub` | `orange.600` |

### Dark

| Token | Valeur |
| --- | --- |
| `background.proEdito` | `green.600` |
| `background.sceneClub` | `orange.600` |
| `icon.proEdito` | `green.500` |
| `icon.sceneClub` | `orange.500` |